### PR TITLE
Configuração de ESLint e EditorConfig no Monorepo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,125 @@
+# EditorConfig - Configurações de estilo de código para desenvolvimento em equipe
+# Documentação oficial: https://EditorConfig.org
+
+# Indica que este é o arquivo raiz de configuração
+# Impite que editores procurem por arquivos .editorconfig em diretórios superiores
+root = true
+
+# Configurações aplicadas para TODOS os tipos de arquivo
+[*]
+# Codificação de caracteres - UTF-8 é o padrão universal para suportar acentos e caracteres especiais
+charset = utf-8
+
+# Tipo de quebra de linha - LF (Line Feed) é o padrão Unix/Linux/Mac
+# Recomendado para projetos cross-platform e evitar conflitos no Git
+end_of_line = lf
+
+# Insere uma linha nova vazia no final de cada arquivo
+# Importante para conformidade com padrões POSIX e evitar warnings em ferramentas
+insert_final_newline = true
+
+# Remove automaticamente espaços em branco no final das linhas
+# Reduz "ruído" em commits do Git e mantém o código limpo
+trim_trailing_whitespace = true
+
+# Define que a indentação será feita com ESPAÇOS (ao invés de tabs)
+# Espaços garantem visualização consistente em todos os editores e sistemas
+indent_style = space
+
+# Define 4 ESPAÇOS por nível de indentação (padrão comum em TypeScript empresarial)
+indent_size = 4
+
+# =============================================================================
+# CONFIGURAÇÕES ESPECÍFICAS POR TIPO DE ARQUIVO
+# =============================================================================
+
+# Arquivos Markdown (documentação, README, etc.)
+[*.md]
+# Desabilita a remoção de espaços trailing em markdown
+# Espaços duplos no final da linha são usados para quebras de linha em Markdown
+trim_trailing_whitespace = false
+
+# Desabilita limite de linha para markdown
+# Texto em markdown frequentemente excede 80/100 caracteres
+max_line_length = off
+
+# =============================================================================
+# ARQUIVOS DE CÓDIGO FRONTEND (React + TypeScript)
+# =============================================================================
+
+# TypeScript, TypeScript React, JavaScript e JavaScript React
+[*.{ts,tsx,js,jsx}]
+# 4 espaços de indentação para melhor legibilidade de código TypeScript
+indent_size = 4
+
+# Comprimento máximo recomendado por linha
+# Facilita leitura side-by-side e code review
+max_line_length = 100
+
+# =============================================================================
+# ARQUIVOS DE CONFIGURAÇÃO E ESTILO
+# =============================================================================
+
+# Arquivos JSON (package.json, tsconfig.json, etc.)
+[*.json]
+indent_size = 4
+
+# Arquivos de estilo (CSS, SCSS, Less)
+[*.{css,scss,less}]
+indent_size = 4
+
+# Arquivos HTML
+[*.html]
+indent_size = 4
+
+# Arquivos XML
+[*.xml]
+indent_size = 4
+
+# Arquivos YAML (GitHub Actions, configurações Docker, etc.)
+[*.{yml,yaml}]
+indent_size = 2  # YAML tradicionalmente usa 2 espaços
+
+# =============================================================================
+# ARQUIVOS DE TESTES E DOCUMENTAÇÃO DE COMPONENTES
+# =============================================================================
+
+# Arquivos de teste (Jest, Testing Library, etc.)
+[*.{test,spec}.{ts,tsx,js,jsx}]
+indent_size = 4
+
+# Arquivos do Storybook
+[*.stories.{ts,tsx}]
+indent_size = 4
+
+# =============================================================================
+# ARQUIVOS ESPECIAIS QUE REQUEREM TABS
+# =============================================================================
+
+# Makefiles exigem tabs para funcionar corretamente
+[Makefile]
+indent_style = tab
+
+# Arquivos batch do Windows
+[*.bat]
+indent_style = tab
+
+# Scripts shell (bash, zsh, etc.)
+[*.sh]
+indent_style = tab
+
+# =============================================================================
+# ARQUIVOS DE CONFIGURAÇÃO DO PROJETO
+# =============================================================================
+
+[.eslintrc.json]
+indent_size = 4
+
+[.prettierrc]
+indent_size = 4
+
+[tsconfig.json]
+indent_size = 4
+
+[package.json]
+indent_size = 4

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,35 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint", "import"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+  ],
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  env: {
+    browser: true,
+    es2020: true,
+    node: true,
+  },
+  ignorePatterns: ["node_modules", "dist", "build"],
+  settings: {
+    react: {
+      version: "detect"
+    }
+  },
+  rules: {
+    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-explicit-any": "warn",
+  }
+};
+
+module.exports = config;

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ client/build
 # Cucumber test reports
 client/reports/
 cucumber-report.*
+
+# ignore server assets folder
+tmp_data/

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true,
+  extends: ["../.eslintrc.js"],
+  parserOptions: {
+    project: "./tsconfig.json",
+    tsconfigRootDir: __dirname,
+  },
+  env: {
+    browser: true,
+  },
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,12 @@
     "client": "PORT=3004 npm start --prefix client",
     "build": "npm run build --prefix client",
     "test": "npm test --prefix client",
-    "lint": "npm run lint --prefix client"
+    "lint:client": "eslint client --ext .ts,.tsx",
+    "lint:server": "eslint server --ext .ts",
+    "lint": "npm run lint:client && npm run lint:server",
+    "lint:fix:client": "eslint client --ext .ts,.tsx --fix",
+    "lint:fix:server": "eslint server --ext .ts --fix",
+    "lint:fix": "npm run lint:fix:client && npm run lint:fix:server"
   },
   "devDependencies": {
     "concurrently": "^8.2.2"

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true, // ADICIONE aqui no server
+  extends: ["../.eslintrc.js"],
+  parserOptions: {
+    project: "./tsconfig.json", 
+    tsconfigRootDir: __dirname,
+  },
+  env: {
+    node: true,
+    browser: false,
+  },
+};
+
+module.exports = config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./client/tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true
+  },
+  "include": [
+    "client/src/**/*",
+    "server/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "build"
+  ]
+}


### PR DESCRIPTION
Este PR adiciona a configuração inicial de **ESLint** e **EditorConfig** ao projeto monorepo, estabelecendo padrões de estilo, formatação e qualidade de código entre o *client* e o *server*.

## ✅ O que foi adicionado

### **1. ESLint**

* Configuração unificada no root do projeto.
* Regras base para JavaScript/TypeScript.
* Suporte a arquivos `.ts` e `.tsx` no client e `.ts` no server.
* Scripts para rodar lint e auto-fix:

  ```
  npm run lint # roda verificações(a configuração atual parece estar quebrada)
  npm run lint:fix # concerta oque for possível automaticamente
  ```
* Ajustes automáticos de estilo onde possível (via `--fix`).

### **2. EditorConfig**

* Padronização de:

  * indentação (spaces)
  * tamanho da indentação
  * charset
  * trim de espaços ao salvar
  * end-of-line

Certifique-se de ter a extensão instalada (caso use VSCode):
[EditorConfig vscode](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)

Ao salvar arquivos, o editor aplicará automaticamente as regras definidas no `.editorconfig`.

### Observações adicionais

- Outras adições possíveis para padronização, poderia ser um .npmrc global, embora ele pudesse unificar configurações de registro, cache ou lockfile entre os pacotes, sua inclusão poderia gerar muitas mudanças inesperadas em builds existentes e na resolução de dependências. 
- Além disso poderia colocar o *Prettier* junto com o editorconfig para aplicar as configs em todos os arquivos automaticamente, mas provavelmente ia gerar muitas alterações, então nao fiz.